### PR TITLE
feat: support other mb urls

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -8,7 +8,11 @@
     "build": "tsc",
     "pretty": "prettier -w ./**/*",
     "lint": "eslint . --ext .ts",
-    "lint-fix": "eslint . --ext .ts --fix"
+    "lint-fix": "eslint . --ext .ts --fix",
+    "mb:up": "docker run -d --name mb -p 2525:2525 -p 12345:12345 -p 12346:12346 bbyars/mountebank:2.6.0 mb start",
+    "mb:up-on-port-2524": "docker run -d --name mb -p 2524:2525 -p 12345:12345 -p 12346:12346 bbyars/mountebank:2.6.0 mb start",
+    "test-different-mb-url": "MB_PORT=2524 npm run test-ci -- -g ^Mountebank",
+    "mb:down": "docker kill mb && docker rm mb"
   },
   "repository": {
     "type": "git",

--- a/integration-tests/src/mountebank.test.ts
+++ b/integration-tests/src/mountebank.test.ts
@@ -16,7 +16,9 @@ async function getImposterResponseCode(): Promise<number> {
 
 describe('Mountebank', () => {
   // only runs on local machine for now
-  const mb = new Mountebank();
+  const mb = new Mountebank().withURL(
+    `http://localhost:${process.env.MB_PORT || '2525'}`
+  );
 
   it('is running', async () => {
     // act
@@ -44,7 +46,6 @@ describe('Mountebank', () => {
     expect(responseCode).to.equal(222);
   });
 
-
   it('can query an imposter', async () => {
     // act
     const imposter = await mb.getImposter(port);
@@ -63,7 +64,7 @@ describe('Mountebank', () => {
     try {
       await getImposterResponseCode();
     } catch (error) {
-      expect(error).to.match(/(?:ECONNREFUSED)/);
+      expect(error).to.match(/(?:ECONNREFUSED|ECONNRESET)/);
       return;
     }
     assert.fail('the request should have failed');

--- a/project/src/mountebank.ts
+++ b/project/src/mountebank.ts
@@ -2,14 +2,22 @@ import request = require('superagent');
 import { Imposter } from './imposter';
 
 export class Mountebank {
-  private adminUrl: string;
+  private mountebankUrl: string;
 
-  constructor(mountebankUrl = 'localhost', public logErrorResults = false) {
-    this.adminUrl = `http://${mountebankUrl}:2525`;
+  constructor(
+    mountebankHostname = 'localhost',
+    public logErrorResults = false
+  ) {
+    this.mountebankUrl = `http://${mountebankHostname}:2525`;
+  }
+
+  public withURL(mountebankUrl: string) {
+    this.mountebankUrl = mountebankUrl;
+    return this;
   }
 
   public async checkIsAlive(logIfNotAlive = false): Promise<boolean> {
-    const url = `${this.adminUrl}/`;
+    const url = `${this.mountebankUrl}/`;
     const result = await request.get(url);
     if (result.statusCode == 200) return true;
 
@@ -27,7 +35,7 @@ export class Mountebank {
     } catch (error) {} // eslint-disable-line
 
     const response = await request
-      .post(`${this.adminUrl}/imposters`)
+      .post(`${this.mountebankUrl}/imposters`)
       .send(JSON.stringify(imposter));
 
     if (response.statusCode != 201)
@@ -37,11 +45,13 @@ export class Mountebank {
   }
 
   public async deleteImposter(port: number): Promise<void> {
-    await request.delete(`${this.adminUrl}/imposters/${port}`);
+    await request.delete(`${this.mountebankUrl}/imposters/${port}`);
   }
 
   public async getImposter(port: number): Promise<Imposter> {
-    const response = await request.get(`${this.adminUrl}/imposters/${port}`).accept('application/json');
+    const response = await request
+      .get(`${this.mountebankUrl}/imposters/${port}`)
+      .accept('application/json');
     return response.body;
   }
 }


### PR DESCRIPTION
e.g. a different mb port

background:

I was trying to use `ts-mountebank` in a kata, and wanted to run mb in docker without enforcing a specific host-side port. see [here](https://github.com/nitsanavni/katas/blob/main/traefik-exploration/traefik.test.ts#L17)