### PR TITLE
feat: adding withQuery into the predicate

### DIFF
--- a/project/package-lock.json
+++ b/project/package-lock.json
@@ -1385,6 +1385,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
       "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
@@ -2644,6 +2645,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
       "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.",
       "dependencies": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.2",

--- a/project/src/imposter.test.ts
+++ b/project/src/imposter.test.ts
@@ -22,13 +22,13 @@ describe('DefaultImposter', () => {
 describe('Imposter', () => {
   it('should not record requests by default', () => {
     const imp = new Imposter();
-    
+
     expect(imp.recordRequests).to.be.undefined;
-  })
+  });
 
   it('should record requests when set', () => {
     const imp = new Imposter().withRecordRequests(true);
-    
+
     expect(imp.recordRequests).to.be.true;
-  })
-})
+  });
+});

--- a/project/src/imposter.ts
+++ b/project/src/imposter.ts
@@ -9,7 +9,7 @@ export class Imposter {
   public stubs: Stub[] = [];
   public name?: string = undefined;
   public recordRequests?: boolean = undefined;
-  
+
   // these properties are only populated when queried from MB
   public numberOfRequests = 0;
   public requests: IRequest[] = [];
@@ -29,7 +29,7 @@ export class Imposter {
     return this;
   }
 
-  withRecordRequests(recordRequests: boolean) : Imposter {
+  withRecordRequests(recordRequests: boolean): Imposter {
     this.recordRequests = recordRequests;
     return this;
   }

--- a/project/src/predicate.flexi-predicate.test.ts
+++ b/project/src/predicate.flexi-predicate.test.ts
@@ -33,7 +33,7 @@ describe('Predicate', () => {
         .withBody(false)
         .toJSON();
 
-        expect(pred.exists.body).to.be.false;
-    })
+      expect(pred.exists.body).to.be.false;
+    });
   });
 });

--- a/project/src/predicate.ts
+++ b/project/src/predicate.ts
@@ -19,6 +19,7 @@ export class FlexiPredicate implements Predicate {
   operator: Operator = Operator.equals;
   method: HttpMethod | undefined = undefined;
   path: string | undefined = undefined;
+  query: string | undefined = undefined
   private _body?: string = undefined;
 
   headers: Map<string, string> = new Map<string, string>();
@@ -34,6 +35,10 @@ export class FlexiPredicate implements Predicate {
   }
   withPath(path: string): FlexiPredicate {
     this.path = path;
+    return this;
+  }
+  withQuery(query: string): FlexiPredicate {
+    this.query = query;
     return this;
   }
   withMethod(method: HttpMethod): FlexiPredicate {
@@ -70,6 +75,11 @@ export class FlexiPredicate implements Predicate {
     if (this.path) {
       res.path = this.path;
     }
+
+    if (this.query) {
+      res.query = this.query
+    }
+
     if (this._body !== undefined) {
       res.body = this._body;
     }
@@ -82,6 +92,7 @@ export class FlexiPredicate implements Predicate {
 export class EqualPredicate implements Predicate {
   method: HttpMethod = HttpMethod.GET;
   path = '/';
+  query: string | undefined = undefined
   private _body?: string = undefined;
 
   headers: Map<string, string> = new Map<string, string>();
@@ -92,6 +103,10 @@ export class EqualPredicate implements Predicate {
   }
   withPath(path: string): EqualPredicate {
     this.path = path;
+    return this;
+  }
+  withQuery(query: string): EqualPredicate {
+    this.query = query;
     return this;
   }
   withMethod(method: HttpMethod): EqualPredicate {
@@ -128,6 +143,11 @@ export class EqualPredicate implements Predicate {
     if (this.path) {
       res.path = this.path;
     }
+
+    if (this.query) {
+      res.query = this.query
+    }
+
     if (this._body) {
       res.body = this._body;
     }

--- a/project/src/proxy/proxy.test.ts
+++ b/project/src/proxy/proxy.test.ts
@@ -1,7 +1,6 @@
 import { assert } from 'chai';
 import { Proxy, ProxyMode } from './proxy';
 
-
 describe('Proxy', () => {
   describe('can be initialized correctly', () => {
     const to = 'http://localhost:5123';

--- a/project/src/request.ts
+++ b/project/src/request.ts
@@ -1,9 +1,9 @@
 export interface IRequest {
-    requestFrom?: string;
-    method?: string;
-    path?: string;
-    query?: any;
-    headers?: any;
-    body?: any;
-    timestamp: string; 
+  requestFrom?: string;
+  method?: string;
+  path?: string;
+  query?: any;
+  headers?: any;
+  body?: any;
+  timestamp: string;
 }


### PR DESCRIPTION
We found that there was no handling in the Predicate to pass querystrings, so added it.

```javascript
...

  new EqualPredicate()
    .withMethod(HttpMethod.GET)
    .withPath('/users')
    .withQuery({ sortFormat: true, limit: 5 })

...

```