### PR TITLE
Add Query String to FlexiPredicate

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,7 +34,7 @@ jobs:
     - run: npm run unit-test
     - run: npm run pack
     # todo: use github packages
-    - run: npm i "file:../project/anev-ts-mountebank-1.5.0.tgz" --save-dev
+    - run: npm i "file:../project/anev-ts-mountebank-1.6.0.tgz" --save-dev
       working-directory: integration-tests
     - run: npm ci
       working-directory: integration-tests

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ mb
 
 I recommend reading the [Mountebank documentation](http://www.mbtest.org/docs/api/overview) for a deeper understanding of their API.
 
-For more samples on how to use this package check this blog: https://angela-evans.com/easy-api-tests-with-mountebank/
+For more samples on how to use this package check this blog: https://angela-evans.com/easy-api-tests-with-mountebank/ or the integration tests.
 
 ### Create Imposter
 ```typescript

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ let imposter = new Imposter().withPort(port).withStub(
 await mb.createImposter(imposter);
 ```
 
+### Check for QueryString
+Add a query to the stub. For usages check the tests in ./integration-tests/predicate.flexi-predicate.query.mb-tests.ts
+```typescript
+new Stub()
+    .withPredicate(
+    new FlexiPredicate()
+        .withOperator(Operator.equals)
+        .withPath('/testpath')
+        .withQuery({name: 'x', max: 5})
+    )
+    .withResponse(new DefaultResponse('found', 222))
+```
+
 ### Create Debug Proxy
 A simple proxy which always proxies the request and records the responses.
 This is useful to 

--- a/integration-tests/src/predicate.flexi-predicate.body.mb-test.ts
+++ b/integration-tests/src/predicate.flexi-predicate.body.mb-test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import request = require('superagent');
+
+import {
+  Imposter,
+  Mountebank,
+  Stub,
+  FlexiPredicate,
+  Operator,
+  DefaultResponse,
+} from '@anev/ts-mountebank';
+
+const port = 12345;
+const path = '/testpath';
+async function getImposterResponseCode(body: any): Promise<number> {
+  return (await request.post(`http://localhost:${port}${path}`).send(body))
+  .statusCode;
+}
+
+describe('The flexi predicate works with query', () => {
+  // only runs on local machine for now
+  const mb = new Mountebank();
+
+  const tests = [
+    {
+      predicateBody: {name: 'x', max: 5},
+      matches: [{name: 'x', max: 5}, {name: 'x', max: 5, min: 1}],
+      nonMatching: [{name: 'x'}, {name: 'x', max: 6}],
+    },
+
+  ];
+
+  tests.forEach(async (test) => {
+    describe(`Body works for predicate '${JSON.stringify(test.predicateBody)}'`, () => {
+      before(async () => {
+        const imposter = new Imposter()
+          .withPort(port)
+          .withStub(
+            new Stub()
+              .withPredicate(
+                new FlexiPredicate()
+                  .withOperator(Operator.equals)
+                  .withPath(path)
+                  .withBody(test.predicateBody)
+              )
+              .withResponse(new DefaultResponse('found', 222))
+          );
+
+        await mb.createImposter(imposter);
+      });
+
+      test.matches.forEach(async (match) => {
+        it(`works with match '${JSON.stringify(match)}'`, async () => {
+          // assert
+          const responseCode = await getImposterResponseCode(match);
+          expect(responseCode).to.equal(222);
+        });
+      });
+
+      test.nonMatching.forEach(async (nonMatch) => {
+        it(`does not work with '${JSON.stringify(nonMatch)}'`, async () => {
+          // assert
+          const responseCode = await getImposterResponseCode(nonMatch);
+          expect(responseCode).to.equal(200);
+        });
+      });
+    });
+  });
+});

--- a/integration-tests/src/proxy/proxy.test.ts
+++ b/integration-tests/src/proxy/proxy.test.ts
@@ -33,7 +33,7 @@ describe('Proxy', () => {
       it(`can create a debug proxy for mode ${test.mode}`, async () => {
         const mb = new Mountebank();
 
-        const body = 'yippie';
+        const body = {x: 'yippie'};
         const responseImposter = new Imposter()
           .withPort(port)
           .withStub(
@@ -81,7 +81,7 @@ describe('Proxy', () => {
           `http://localhost:${proxyPort}${testPath}`
         );
         expect(response.statusCode).to.equal(firstImposterResponseStatus);
-        expect(response.body).to.equal(body);
+        expect(response.body).to.deep.equal(body);
 
         try {
           await mb.createImposter(newImposter);

--- a/project/package.json
+++ b/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anev/ts-mountebank",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Mountebank client for TS / node ",
   "scripts": {
     "release": "npm run build && npm run test && npm publish --access=public",

--- a/project/src/predicate.ts
+++ b/project/src/predicate.ts
@@ -17,9 +17,10 @@ export enum Operator {
 
 export class FlexiPredicate implements Predicate {
   operator: Operator = Operator.equals;
-  method: HttpMethod | undefined = undefined;
-  path: string | undefined = undefined;
-  private _body?: string = undefined;
+  method?: HttpMethod = undefined;
+  path?: string = undefined;
+  query?: any = undefined;
+  body?: string = undefined;
 
   headers: Map<string, string> = new Map<string, string>();
 
@@ -32,21 +33,29 @@ export class FlexiPredicate implements Predicate {
     this.headers.set(header, value);
     return this;
   }
+
+  withQuery(query: any): FlexiPredicate {
+    this.query = query;
+    return this;
+  }
+  
   withPath(path: string): FlexiPredicate {
     this.path = path;
     return this;
   }
+
   withMethod(method: HttpMethod): FlexiPredicate {
     this.method = method;
     return this;
   }
+  
   withBearerToken(token: string): FlexiPredicate {
     this.withHeader('authorization', 'bearer ' + token);
     return this;
   }
 
   withBody(body: any): FlexiPredicate {
-    this._body = body;
+    this.body = body;
     return this;
   }
   toJSON(): any {
@@ -70,8 +79,13 @@ export class FlexiPredicate implements Predicate {
     if (this.path) {
       res.path = this.path;
     }
-    if (this._body !== undefined) {
-      res.body = this._body;
+
+    if(this.query !== undefined) {
+      res.query = this.query;
+    }
+
+    if (this.body !== undefined) {
+      res.body = this.body;
     }
     return {
       [this.operator]: res,
@@ -83,6 +97,9 @@ export class EqualPredicate implements Predicate {
   method: HttpMethod = HttpMethod.GET;
   path = '/';
   private _body?: string = undefined;
+  // does not have a queryString option because you can 
+  // just use the FlexiPredicate
+  // The EqualPredicate is just left here for backwards compatibility
 
   headers: Map<string, string> = new Map<string, string>();
 
@@ -107,6 +124,7 @@ export class EqualPredicate implements Predicate {
     this._body = body;
     return this;
   }
+  
   toJSON(): any {
     const res: any = {};
 


### PR DESCRIPTION
FlexiPredicate now allows checks for the query string:
```
new FlexiPredicate()
        .withOperator(Operator.equals)
        .withPath('/testpath')
        .withQuery({name: 'x', max: 5})
    )
```