### PR TITLE
Allow setting the response mode

### DIFF
--- a/project/src/response.test.ts
+++ b/project/src/response.test.ts
@@ -18,4 +18,16 @@ describe('Response', () => {
       assert.equal('application/json', res.headers.get('Content-Type'));
     });
   });
+  describe('#withMode', () => {
+    const res = new Response();
+    it('should not set _mode by default', () => {
+      const payload = res.toJSON();
+      assert.isUndefined(payload.is._mode);
+    });
+    it('should have a mode of "binary"', () => {
+      res.withMode('binary');
+      const payload = res.toJSON();
+      assert.equal(payload.is._mode, 'binary');
+    });
+  });
 });

--- a/project/src/response.ts
+++ b/project/src/response.ts
@@ -1,7 +1,10 @@
+type ResponseMode = 'text' | 'binary';
+
 export class Response {
   statusCode = 200;
   body?: string = undefined;
   headers: Map<string, string>;
+  mode?: ResponseMode;
   constructor() {
     this.headers = new Map<string, string>();
   }
@@ -24,6 +27,11 @@ export class Response {
     return this;
   }
 
+  withMode(mode: ResponseMode): this {
+    this.mode = mode;
+    return this;
+  }
+
   toJSON(): any {
     const res: any = {};
 
@@ -43,6 +51,9 @@ export class Response {
     }
     if (this.statusCode) {
       res.statusCode = this.statusCode;
+    }
+    if (this.mode) {
+      res._mode = this.mode;
     }
 
     return { is: res };


### PR DESCRIPTION
HTTP Responses in Mountebank allow the configuration of "text" or "binary" bodies via the `_mode` option. This is required to allow bodies to respond with a binary body (which can be specified by passing a response body encoded as base64). More information can be found on the Mountebank [HTTP protocols page](http://www.mbtest.org/docs/protocols/http).

This PR adds the ability to set the `_mode` value for a response in a backwards compatible way (despite `"text"` being the default value, it doesn't set it unless it's explicitly set by the consumer).

This _doesn't_ add any additional QOL features for binary responses like base64 encoding a `Buffer` or `UintNArray` via a `withBinaryBody` method. More than happy to add that if you believe it is in the scope of this library to handle considering it does already have a similar QOL feature in the `withJSONBody` method.

(also, have only added a unit test — it didn't seem to fit into the current integration test suite but happy to craft something for that also)