### PR TITLE
Return this instead of class in builder methods

### DIFF
--- a/project/src/imposter.ts
+++ b/project/src/imposter.ts
@@ -9,27 +9,27 @@ export class Imposter {
   public stubs: Stub[] = [];
   public name?: string = undefined;
   public recordRequests?: boolean = undefined;
-  
+
   // these properties are only populated when queried from MB
   public numberOfRequests = 0;
   public requests: IRequest[] = [];
 
-  withStub(s: Stub): Imposter {
+  withStub(s: Stub): this {
     this.stubs.push(s);
     return this;
   }
 
-  withPort(p: number): Imposter {
+  withPort(p: number): this {
     this.port = p;
     return this;
   }
 
-  withName(name: string): Imposter {
+  withName(name: string): this {
     this.name = name;
     return this;
   }
 
-  withRecordRequests(recordRequests: boolean) : Imposter {
+  withRecordRequests(recordRequests: boolean): this {
     this.recordRequests = recordRequests;
     return this;
   }

--- a/project/src/mountebank.ts
+++ b/project/src/mountebank.ts
@@ -11,7 +11,7 @@ export class Mountebank {
     this.mountebankUrl = `http://${mountebankHostname}:2525`;
   }
 
-  public withURL(mountebankUrl: string) {
+  public withURL(mountebankUrl: string): this {
     this.mountebankUrl = mountebankUrl;
     return this;
   }

--- a/project/src/predicate.ts
+++ b/project/src/predicate.ts
@@ -24,37 +24,37 @@ export class FlexiPredicate implements Predicate {
 
   headers: Map<string, string> = new Map<string, string>();
 
-  withOperator(operator: Operator): FlexiPredicate {
+  withOperator(operator: Operator): this {
     this.operator = operator;
     return this;
   }
 
-  withHeader(header: string, value: string): FlexiPredicate {
+  withHeader(header: string, value: string): this {
     this.headers.set(header, value);
     return this;
   }
 
-  withQuery(query: any): FlexiPredicate {
+  withQuery(query: any): this {
     this.query = query;
     return this;
   }
   
-  withPath(path: string): FlexiPredicate {
+  withPath(path: string): this {
     this.path = path;
     return this;
   }
 
-  withMethod(method: HttpMethod): FlexiPredicate {
+  withMethod(method: HttpMethod): this {
     this.method = method;
     return this;
   }
   
-  withBearerToken(token: string): FlexiPredicate {
+  withBearerToken(token: string): this {
     this.withHeader('authorization', 'bearer ' + token);
     return this;
   }
 
-  withBody(body: any): FlexiPredicate {
+  withBody(body: any): this {
     this.body = body;
     return this;
   }
@@ -103,24 +103,24 @@ export class EqualPredicate implements Predicate {
 
   headers: Map<string, string> = new Map<string, string>();
 
-  withHeader(header: string, value: string): EqualPredicate {
+  withHeader(header: string, value: string): this {
     this.headers.set(header, value);
     return this;
   }
-  withPath(path: string): EqualPredicate {
+  withPath(path: string): this {
     this.path = path;
     return this;
   }
-  withMethod(method: HttpMethod): EqualPredicate {
+  withMethod(method: HttpMethod): this {
     this.method = method;
     return this;
   }
-  withBearerToken(token: string): EqualPredicate {
+  withBearerToken(token: string): this {
     this.withHeader('authorization', 'bearer ' + token);
     return this;
   }
 
-  withBody(body: any): EqualPredicate {
+  withBody(body: any): this {
     this._body = body;
     return this;
   }

--- a/project/src/proxy/predicate-generator.ts
+++ b/project/src/proxy/predicate-generator.ts
@@ -5,7 +5,7 @@ import { Matches } from './matches';
 export class PredicateGenerator {
   matches?: Matches = undefined;
 
-  withMatches(matches: Matches): PredicateGenerator {
+  withMatches(matches: Matches): this {
     this.matches = matches;
     return this;
   }

--- a/project/src/proxy/proxy.ts
+++ b/project/src/proxy/proxy.ts
@@ -18,17 +18,17 @@ export class Proxy {
     this.predicateGenerators = [];
   }
 
-  withMode(mode: ProxyMode): Proxy {
+  withMode(mode: ProxyMode): this {
     this.mode = mode;
     return this;
   }
 
-  withPredicateGenerator(generator: PredicateGenerator): Proxy {
+  withPredicateGenerator(generator: PredicateGenerator): this {
     this.predicateGenerators?.push(generator);
     return this;
   }
 
-  withAddWaitBehavior(addWaitBehavior: boolean): Proxy {
+  withAddWaitBehavior(addWaitBehavior: boolean): this {
     this.addWaitBehavior = addWaitBehavior;
     return this;
   }

--- a/project/src/response.ts
+++ b/project/src/response.ts
@@ -5,21 +5,21 @@ export class Response {
   constructor() {
     this.headers = new Map<string, string>();
   }
-  withHeader(name: string, value: string): Response {
+  withHeader(name: string, value: string): this {
     this.headers.set(name, value);
     return this;
   }
-  withStatusCode(statusCode: number): Response {
+  withStatusCode(statusCode: number): this {
     this.statusCode = statusCode;
     return this;
   }
-  withJSONBody(body: any): Response {
+  withJSONBody(body: any): this {
     this.withHeader('Content-Type', 'application/json'); // set the header to json for convenience
     this.body = JSON.stringify(body);
     return this;
   }
 
-  withBody(body: any): Response {
+  withBody(body: any): this {
     this.body = body;
     return this;
   }

--- a/project/src/stub.ts
+++ b/project/src/stub.ts
@@ -12,17 +12,17 @@ export class Stub {
     this.responses = [];
   }
 
-  withResponse(response: Response): Stub {
+  withResponse(response: Response): this {
     this.responses.push(response);
     return this;
   }
 
-  withProxy(proxy: Proxy): Stub {
+  withProxy(proxy: Proxy): this {
     this.responses.push(proxy);
     return this;
   }
 
-  withPredicate(predicate: Predicate): Stub {
+  withPredicate(predicate: Predicate): this {
     this.predicates.push(predicate);
     return this;
   }


### PR DESCRIPTION
I don't know if this is something that you're interested in accepting but figured I'd submit this and ask. This _can_ be worked around as a consumer with some type casting 🙂

Currently, the class methods exported from classes `ts-mountebank` that use the builder patter (`with<property>(...)`), are typed as returning a hardcoded class type — this prevents consumers from extending the classes in an ergonomic way.

In the below example, you can see that the first image (current behaviour), after calling `withName(...)` on the instance of `AutoPortImposter`, typescript sees the return type as being the type of the parent class, where it's actually an instance of the subclass (or `this`). This PR modifies the return type to be `this` which allows extending classes defined in this library and using the builder pattern as expected.

Before this PR:
<img width="576" alt="image" src="https://github.com/AngelaE/ts-mountebank/assets/4160665/bd4728a9-6c02-4beb-8d0a-6c8fc9b391f2">

After this PR:
<img width="496" alt="Screenshot 2023-07-11 at 7 16 35 am" src="https://github.com/AngelaE/ts-mountebank/assets/4160665/7d24e0fb-c88e-4886-b730-0fd937141992">
