### PR TITLE
add support for nodejs v20.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,9 +18,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8.15.4
           run_install: false

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/devbox.json
+++ b/devbox.json
@@ -1,8 +1,8 @@
 {
   "packages": [
     "docker@latest",
-    "nodejs@18.19.1",
-    "corepack_18@18.19.1"
+    "nodejs@20.11.1",
+    "corepack_20@20.11.1"
   ],
   "shell": {
     "init_hook": [

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,23 +1,23 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "corepack_18@18.19.1": {
-      "last_modified": "2024-02-26T19:46:43Z",
-      "resolved": "github:NixOS/nixpkgs/548a86b335d7ecd8b57ec617781f5e652ab0c38e#corepack_18",
+    "corepack_20@20.11.1": {
+      "last_modified": "2024-02-24T23:06:34Z",
+      "resolved": "github:NixOS/nixpkgs/9a9dae8f6319600fa9aebde37f340975cab4b8c0#corepack_20",
       "source": "devbox-search",
-      "version": "18.19.1",
+      "version": "20.11.1",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/chym073v5xgndf3blsp3r1368v85h4j4-corepack-nodejs-18.19.1"
+          "store_path": "/nix/store/zcm9qj1i37bkcfdjizgb1hhzvkidljdn-corepack-nodejs-20.11.1"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/9d4g0s21xfx470whd0kc8r8cp2ly0g70-corepack-nodejs-18.19.1"
+          "store_path": "/nix/store/i4d2ws68f1ckwhlb0lzf2gkl3kf1mkng-corepack-nodejs-20.11.1"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/c744s23f0f67h82rxh6cpr8nz0cakzlc-corepack-nodejs-18.19.1"
+          "store_path": "/nix/store/x9rark9c19l7whs5i7a2i36hzmdzbh2h-corepack-nodejs-20.11.1"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/d29gg8ivq1bvwjbl1pm2lggmkcgynckq-corepack-nodejs-18.19.1"
+          "store_path": "/nix/store/5rkmxlw4v9i3vf4xplwsqfkswy514d8p-corepack-nodejs-20.11.1"
         }
       }
     },
@@ -41,23 +41,23 @@
         }
       }
     },
-    "nodejs@18.19.1": {
-      "last_modified": "2024-02-26T19:46:43Z",
-      "resolved": "github:NixOS/nixpkgs/548a86b335d7ecd8b57ec617781f5e652ab0c38e#nodejs_18",
+    "nodejs@20.11.1": {
+      "last_modified": "2024-02-24T23:06:34Z",
+      "resolved": "github:NixOS/nixpkgs/9a9dae8f6319600fa9aebde37f340975cab4b8c0#nodejs_20",
       "source": "devbox-search",
-      "version": "18.19.1",
+      "version": "20.11.1",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/fxly5x870ssyw5rbvdi58jbhc4j03mzk-nodejs-18.19.1"
+          "store_path": "/nix/store/xr7qgwzvymigkn4lhz8hzdky765m32r4-nodejs-20.11.1"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/6iirvvbd99b7dfwk3z8phry2yliwvm99-nodejs-18.19.1"
+          "store_path": "/nix/store/gdjc5gacmfpj6warfxhfkjj3i8vhaxq9-nodejs-20.11.1"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/rzsav2ndbzah0vkmyqpnhcwxp4n0zdm6-nodejs-18.19.1"
+          "store_path": "/nix/store/c0bc4479fbsdmzam1b50yil1ixcaaz4s-nodejs-20.11.1"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/c8phnfr1s43123qm3fmyiq5n1hs5csdv-nodejs-18.19.1"
+          "store_path": "/nix/store/vz13mi0w75q96sfjxz2ylnv8812hvf34-nodejs-20.11.1"
         }
       }
     }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -19,7 +19,7 @@
     "mb:up-on-port-2524": "docker run -d --name mb -p 2524:2525 -p 12345:12345 -p 12346:12346 bbyars/mountebank:2.9.1 mb start",
     "test-different-mb-url": "MB_PORT=2524 pnpm test-ci -- -g ^Mountebank",
     "mb:down": "docker kill mb && docker rm mb",
-    "project:add": "pnpm add -D 'file://../project/anev-ts-mountebank-1.8.3.tgz'",
+    "project:add": "pnpm add -D 'file://../project/anev-ts-mountebank-1.8.2.tgz'",
     "project:remove": "pnpm remove @anev/ts-mountebank"
   },
   "repository": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -33,7 +33,6 @@
     "typescript": "^5.3.3"
   },
   "devDependencies": {
-    "@anev/ts-mountebank": "file:../project/anev-ts-mountebank-1.8.3.tgz",
     "@types/chai": "^4.3.12",
     "@types/mocha": "^10.0.6",
     "@types/superagent": "^8.1.4",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Integration tests for @anev/ts-mountebank ",
   "engines": {
-    "node": ">=16.20.2",
+    "node": ">=20.11",
     "pnpm": ">=8.15.4"
   },
   "scripts": {
@@ -19,7 +19,7 @@
     "mb:up-on-port-2524": "docker run -d --name mb -p 2524:2525 -p 12345:12345 -p 12346:12346 bbyars/mountebank:2.9.1 mb start",
     "test-different-mb-url": "MB_PORT=2524 pnpm test-ci -- -g ^Mountebank",
     "mb:down": "docker kill mb && docker rm mb",
-    "project:add": "pnpm add -D 'file://../project/anev-ts-mountebank-1.8.2.tgz'",
+    "project:add": "pnpm add -D 'file://../project/anev-ts-mountebank-1.8.3.tgz'",
     "project:remove": "pnpm remove @anev/ts-mountebank"
   },
   "repository": {
@@ -33,6 +33,7 @@
     "typescript": "^5.3.3"
   },
   "devDependencies": {
+    "@anev/ts-mountebank": "file:../project/anev-ts-mountebank-1.8.3.tgz",
     "@types/chai": "^4.3.12",
     "@types/mocha": "^10.0.6",
     "@types/superagent": "^8.1.4",

--- a/integration-tests/src/mountebank.test.ts
+++ b/integration-tests/src/mountebank.test.ts
@@ -64,10 +64,10 @@ describe('Mountebank', () => {
     try {
       await getImposterResponseCode();
     } catch (error) {
-      if(process.version.includes('v20')) {
-        expect((error as AggregateError).errors).to.match(/(?:ECONNREFUSED|ECONNRESET)/);
-      } else {
+      if(process.version.startsWith('v16') || process.version.startsWith('v18')) {
         expect(error).to.match(/(?:ECONNREFUSED|ECONNRESET)/);
+      } else {
+        expect((error as AggregateError).errors).to.match(/(?:ECONNREFUSED|ECONNRESET)/);
       }
       return;
     }

--- a/integration-tests/src/mountebank.test.ts
+++ b/integration-tests/src/mountebank.test.ts
@@ -64,7 +64,11 @@ describe('Mountebank', () => {
     try {
       await getImposterResponseCode();
     } catch (error) {
-      expect(error).to.match(/(?:ECONNREFUSED|ECONNRESET)/);
+      if(process.version.includes('v20')) {
+        expect((error as AggregateError).errors).to.match(/(?:ECONNREFUSED|ECONNRESET)/);
+      } else {
+        expect(error).to.match(/(?:ECONNREFUSED|ECONNRESET)/);
+      }
       return;
     }
     assert.fail('the request should have failed');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": ">=16.20.2",
+    "node": ">=20.11",
     "pnpm": ">=8.15.4"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
     devDependencies:
-      '@anev/ts-mountebank':
-        specifier: file:../project/anev-ts-mountebank-1.8.3.tgz
-        version: file:project/anev-ts-mountebank-1.8.3.tgz
       '@types/chai':
         specifier: ^4.3.12
         version: 4.3.12
@@ -524,6 +521,7 @@ packages:
 
   /asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+    dev: false
 
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
@@ -752,6 +750,7 @@ packages:
 
   /component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+    dev: false
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -780,6 +779,7 @@ packages:
 
   /cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
+    dev: false
 
   /cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -873,6 +873,7 @@ packages:
     dependencies:
       asap: 2.0.6
       wrappy: 1.0.2
+    dev: false
 
   /diff@5.0.0:
     resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
@@ -1159,6 +1160,7 @@ packages:
 
   /fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+    dev: false
 
   /fastq@1.16.0:
     resolution: {integrity: sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==}
@@ -1260,6 +1262,7 @@ packages:
       hexoid: 1.0.0
       once: 1.4.0
       qs: 6.11.2
+    dev: false
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1421,6 +1424,7 @@ packages:
   /hexoid@1.0.0:
     resolution: {integrity: sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==}
     engines: {node: '>=8'}
+    dev: false
 
   /html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -1827,6 +1831,7 @@ packages:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
+    dev: false
 
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2152,6 +2157,7 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
+    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2444,6 +2450,7 @@ packages:
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2722,17 +2729,4 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-    dev: true
-
-  file:project/anev-ts-mountebank-1.8.3.tgz:
-    resolution: {integrity: sha512-G+jShI9MrqbWhp8cqKC2in3OgvCK1rPuywPcrufrTEy7OZxK7Da4T2/LDVMGvclZ6Y3Qo1us84fSFojitDlT0Q==, tarball: file:project/anev-ts-mountebank-1.8.3.tgz}
-    name: '@anev/ts-mountebank'
-    version: 1.8.3
-    engines: {node: '>=20.11', pnpm: '>=8.15.4'}
-    requiresBuild: true
-    dependencies:
-      superagent: 8.1.2
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
     devDependencies:
+      '@anev/ts-mountebank':
+        specifier: file:../project/anev-ts-mountebank-1.8.3.tgz
+        version: file:project/anev-ts-mountebank-1.8.3.tgz
       '@types/chai':
         specifier: ^4.3.12
         version: 4.3.12
@@ -521,7 +524,6 @@ packages:
 
   /asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
-    dev: false
 
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
@@ -750,7 +752,6 @@ packages:
 
   /component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
-    dev: false
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -779,7 +780,6 @@ packages:
 
   /cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
-    dev: false
 
   /cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -873,7 +873,6 @@ packages:
     dependencies:
       asap: 2.0.6
       wrappy: 1.0.2
-    dev: false
 
   /diff@5.0.0:
     resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
@@ -1160,7 +1159,6 @@ packages:
 
   /fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
-    dev: false
 
   /fastq@1.16.0:
     resolution: {integrity: sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==}
@@ -1262,7 +1260,6 @@ packages:
       hexoid: 1.0.0
       once: 1.4.0
       qs: 6.11.2
-    dev: false
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1424,7 +1421,6 @@ packages:
   /hexoid@1.0.0:
     resolution: {integrity: sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==}
     engines: {node: '>=8'}
-    dev: false
 
   /html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -1831,7 +1827,6 @@ packages:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
-    dev: false
 
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2157,7 +2152,6 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
-    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2450,7 +2444,6 @@ packages:
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2729,4 +2722,17 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  file:project/anev-ts-mountebank-1.8.3.tgz:
+    resolution: {integrity: sha512-G+jShI9MrqbWhp8cqKC2in3OgvCK1rPuywPcrufrTEy7OZxK7Da4T2/LDVMGvclZ6Y3Qo1us84fSFojitDlT0Q==, tarball: file:project/anev-ts-mountebank-1.8.3.tgz}
+    name: '@anev/ts-mountebank'
+    version: 1.8.3
+    engines: {node: '>=20.11', pnpm: '>=8.15.4'}
+    requiresBuild: true
+    dependencies:
+      superagent: 8.1.2
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true

--- a/project/package.json
+++ b/project/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@anev/ts-mountebank",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Mountebank client for TS / node ",
   "engines": {
-    "node": ">=16.20.2",
+    "node": ">=20.11",
     "pnpm": ">=8.15.4"
   },
   "scripts": {

--- a/project/package.json
+++ b/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anev/ts-mountebank",
-  "version": "1.8.3",
+  "version": "1.8.2",
   "description": "Mountebank client for TS / node ",
   "engines": {
     "node": ">=20.11",


### PR DESCRIPTION
NodeJS v16 has been EOL. It is hightime to begin supporting NodeJS v20.

1. Update devbox deps to nodejs20 and corepack20.
2. Update package.json with engines node defined to `>=20.11`.
3. Update integration tests to handle the new AggregateError introduced in NodeJS v20 (ECMAScript 2021).
